### PR TITLE
Implement RateLimitedCircuitBreaker

### DIFF
--- a/v2/ratelimited_gobreaker.go
+++ b/v2/ratelimited_gobreaker.go
@@ -1,0 +1,261 @@
+package gobreaker
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// RateLimitedCircuitBreaker is a state machine to prevent sending requests that are likely to fail.
+// It differs from a regular CircuitBreaker in that it has a half-open state that:
+// 1. Allows a rate-limited number of requests to pass through, rejecting requests when the limit is reached
+// 2. Resets the state to closed after a specified timeout
+// 3. Uses the same tripping logic as the Closed state.
+type RateLimitedCircuitBreaker[T any] struct {
+	name            string
+	maxRequests     uint32
+	interval        time.Duration
+	timeout         time.Duration
+	halfOpenTimeout time.Duration
+	readyToTrip     func(counts Counts) bool
+	isSuccessful    func(err error) bool
+	onStateChange   func(name string, from State, to State)
+
+	mutex      sync.Mutex
+	state      State
+	generation uint64
+	counts     Counts
+	expiry     time.Time
+
+	inFlightRequests uint32
+}
+
+// RateLimitedCircuitBreakerSettings configures RateLimitedCircuitBreaker:
+//
+// Settings is the base configuration for the RateLimitedCircuitBreaker.
+//
+// HalfOpenTimeout is the period of the halg-open state,
+// after which the state of the RateLimitedCircuitBreaker becomes closed.
+// If HalfOpenTimeout is less than or equal to 0, the timeout value of the RateLimitedCircuitBreaker is set to 60 seconds.
+type RateLimitedCircuitBreakerSettings struct {
+	Settings
+
+	HalfOpenTimeout time.Duration
+}
+
+// NewRateLimitedCircuitBreaker returns a new RateLimitedCircuitBreaker configured with the given Settings.
+func NewRateLimitedCircuitBreaker[T any](st RateLimitedCircuitBreakerSettings) *RateLimitedCircuitBreaker[T] {
+	cb := new(RateLimitedCircuitBreaker[T])
+
+	cb.name = st.Name
+	cb.onStateChange = st.OnStateChange
+
+	if st.MaxRequests == 0 {
+		cb.maxRequests = 1
+	} else {
+		cb.maxRequests = st.MaxRequests
+	}
+
+	if st.HalfOpenTimeout <= 0 {
+		cb.halfOpenTimeout = defaultTimeout
+	} else {
+		cb.halfOpenTimeout = st.HalfOpenTimeout
+	}
+
+	if st.Interval <= 0 {
+		cb.interval = defaultInterval
+	} else {
+		cb.interval = st.Interval
+	}
+
+	if st.Timeout <= 0 {
+		cb.timeout = defaultTimeout
+	} else {
+		cb.timeout = st.Timeout
+	}
+
+	if st.ReadyToTrip == nil {
+		cb.readyToTrip = defaultReadyToTrip
+	} else {
+		cb.readyToTrip = st.ReadyToTrip
+	}
+
+	if st.IsSuccessful == nil {
+		cb.isSuccessful = defaultIsSuccessful
+	} else {
+		cb.isSuccessful = st.IsSuccessful
+	}
+
+	cb.toNewGeneration(time.Now())
+
+	return cb
+}
+
+// Name returns the name of the RateLimitedCircuitBreaker.
+func (cb *RateLimitedCircuitBreaker[T]) Name() string {
+	return cb.name
+}
+
+// State returns the current state of the RateLimitedCircuitBreaker.
+func (cb *RateLimitedCircuitBreaker[T]) State() State {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
+	now := time.Now()
+	state, _ := cb.currentState(now)
+	return state
+}
+
+// Counts returns internal counters
+func (cb *RateLimitedCircuitBreaker[T]) Counts() Counts {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
+	return cb.counts
+}
+
+// Execute runs the given request if the RateLimitedCircuitBreaker accepts it.
+// Execute returns an error instantly if the RateLimitedCircuitBreaker rejects the request.
+// Otherwise, Execute returns the result of the request.
+// If a panic occurs in the request, the RateLimitedCircuitBreaker handles it as an error
+// and causes the same panic again.
+func (cb *RateLimitedCircuitBreaker[T]) Execute(req func() (T, error)) (T, error) {
+	generation, err := cb.beforeRequest()
+	if err != nil {
+		var defaultValue T
+		return defaultValue, err
+	}
+
+	defer func() {
+		e := recover()
+		if e != nil {
+			cb.afterRequest(generation, false)
+			panic(e)
+		}
+	}()
+
+	result, err := req()
+	cb.afterRequest(generation, cb.isSuccessful(err))
+	return result, err
+}
+
+func (cb *RateLimitedCircuitBreaker[T]) String() string {
+	if cb == nil {
+		return "RateLimitedCircuitBreaker(nil)"
+	}
+
+	return fmt.Sprintf("RateLimitedCircuitBreaker{name: %s, maxRequests: %d, interval: %s, timeout: %s, halfOpenTimeout: %s, state: %s, generation: %d, counts: %v, expiry: %s, inFlightRequests: %d}",
+		cb.name, cb.maxRequests, cb.interval, cb.timeout, cb.halfOpenTimeout, cb.state, cb.generation, cb.counts, cb.expiry, cb.inFlightRequests)
+}
+
+func (cb *RateLimitedCircuitBreaker[T]) beforeRequest() (uint64, error) {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
+	now := time.Now()
+	state, generation := cb.currentState(now)
+
+	if state == StateOpen {
+		return generation, ErrOpenState
+	} else if state == StateHalfOpen && cb.maxRequests > 0 && cb.inFlightRequests >= cb.maxRequests {
+		// If there's already too many in-flight requests in HalfOpen state, reject the request
+		return generation, ErrTooManyRequests
+	}
+
+	cb.counts.onRequest()
+	cb.inFlightRequests++
+	return generation, nil
+}
+
+func (cb *RateLimitedCircuitBreaker[T]) afterRequest(before uint64, success bool) {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
+	cb.inFlightRequests--
+
+	now := time.Now()
+	state, generation := cb.currentState(now)
+	if generation != before {
+		return
+	}
+
+	if success {
+		cb.onSuccess(state, now)
+	} else {
+		cb.onFailure(state, now)
+	}
+}
+
+func (cb *RateLimitedCircuitBreaker[T]) onSuccess(state State, now time.Time) {
+	switch state {
+	case StateClosed:
+		cb.counts.onSuccess()
+	case StateHalfOpen:
+		cb.counts.onSuccess()
+		cb.currentState(now) // Refresh the state after a successful request in HalfOpen state
+	}
+}
+
+func (cb *RateLimitedCircuitBreaker[T]) onFailure(state State, now time.Time) {
+	switch state {
+	case StateClosed, StateHalfOpen:
+		cb.counts.onFailure()
+		if cb.readyToTrip(cb.counts) {
+			cb.setState(StateOpen, now)
+		}
+	}
+}
+
+func (cb *RateLimitedCircuitBreaker[T]) currentState(now time.Time) (State, uint64) {
+	switch cb.state {
+	case StateClosed:
+		if !cb.expiry.IsZero() && cb.expiry.Before(now) {
+			cb.toNewGeneration(now)
+		}
+	case StateHalfOpen:
+		if cb.expiry.Before(now) {
+			cb.setState(StateClosed, now)
+		}
+	case StateOpen:
+		if cb.expiry.Before(now) {
+			cb.setState(StateHalfOpen, now)
+		}
+	}
+	return cb.state, cb.generation
+}
+
+func (cb *RateLimitedCircuitBreaker[T]) setState(state State, now time.Time) {
+	if cb.state == state {
+		return
+	}
+
+	prev := cb.state
+	cb.state = state
+
+	cb.toNewGeneration(now)
+
+	if cb.onStateChange != nil {
+		cb.onStateChange(cb.name, prev, state)
+	}
+}
+
+func (cb *RateLimitedCircuitBreaker[T]) toNewGeneration(now time.Time) {
+	cb.generation++
+	cb.counts.clear()
+
+	var zero time.Time
+	switch cb.state {
+	case StateClosed:
+		if cb.interval == 0 {
+			cb.expiry = zero
+		} else {
+			cb.expiry = now.Add(cb.interval)
+		}
+	case StateOpen:
+		cb.expiry = now.Add(cb.timeout)
+	case StateHalfOpen:
+		cb.expiry = now.Add(cb.halfOpenTimeout)
+	default:
+		cb.expiry = zero
+	}
+}

--- a/v2/ratelimited_gobreaker_test.go
+++ b/v2/ratelimited_gobreaker_test.go
@@ -1,0 +1,332 @@
+package gobreaker
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var defaultRLCB *RateLimitedCircuitBreaker[bool]
+var customRLCB *RateLimitedCircuitBreaker[bool]
+
+type RLStateChange struct {
+	name string
+	from State
+	to   State
+}
+
+var rlStateChange RLStateChange
+
+func pseudoSleepRL(cb *RateLimitedCircuitBreaker[bool], period time.Duration) {
+	if !cb.expiry.IsZero() {
+		cb.expiry = cb.expiry.Add(-period)
+	}
+}
+
+func succeedRL(cb *RateLimitedCircuitBreaker[bool]) error {
+	_, err := cb.Execute(func() (bool, error) { return true, nil })
+	return err
+}
+
+func succeedLaterRL(cb *RateLimitedCircuitBreaker[bool], delay time.Duration) <-chan error {
+	ch := make(chan error)
+	go func() {
+		_, err := cb.Execute(func() (bool, error) {
+			time.Sleep(delay)
+			return true, nil
+		})
+		ch <- err
+	}()
+	return ch
+}
+
+func failRL(cb *RateLimitedCircuitBreaker[bool]) error {
+	msg := "fail"
+	_, err := cb.Execute(func() (bool, error) { return false, errors.New(msg) })
+	if err.Error() == msg {
+		return nil
+	}
+	return err
+}
+
+func causePanicRL(cb *RateLimitedCircuitBreaker[bool]) error {
+	_, err := cb.Execute(func() (bool, error) { panic("oops"); return false, nil })
+	return err
+}
+
+func newCustomRL() *RateLimitedCircuitBreaker[bool] {
+	var customSt Settings
+	customSt.Name = "cb"
+	customSt.MaxRequests = 3
+	customSt.Interval = time.Duration(30) * time.Second
+	customSt.Timeout = time.Duration(90) * time.Second
+	customSt.ReadyToTrip = func(counts Counts) bool {
+		numReqs := counts.Requests
+		failureRatio := float64(counts.TotalFailures) / float64(numReqs)
+
+		counts.clear() // no effect on customRLCB.counts
+
+		return numReqs >= 3 && failureRatio >= 0.6
+	}
+	customSt.OnStateChange = func(name string, from State, to State) {
+		rlStateChange = RLStateChange{name, from, to}
+	}
+
+	var customRLSt RateLimitedCircuitBreakerSettings
+	customRLSt.Settings = customSt
+	customRLSt.HalfOpenTimeout = time.Duration(90) * time.Second
+
+	return NewRateLimitedCircuitBreaker[bool](customRLSt)
+}
+
+func newNegativeDurationRLCB() *RateLimitedCircuitBreaker[bool] {
+	var negativeSt Settings
+	negativeSt.Name = "ncb"
+	negativeSt.Interval = time.Duration(-30) * time.Second
+	negativeSt.Timeout = time.Duration(-90) * time.Second
+
+	var negativeRLSt RateLimitedCircuitBreakerSettings
+	negativeRLSt.Settings = negativeSt
+	negativeRLSt.HalfOpenTimeout = time.Duration(-90) * time.Second
+
+	return NewRateLimitedCircuitBreaker[bool](negativeRLSt)
+}
+
+func init() {
+	defaultRLCB = NewRateLimitedCircuitBreaker[bool](RateLimitedCircuitBreakerSettings{})
+	customRLCB = newCustomRL()
+}
+
+func TestNewRateLimitedCircuitBreaker(t *testing.T) {
+	defaultRLCB := NewRateLimitedCircuitBreaker[bool](RateLimitedCircuitBreakerSettings{})
+	assert.Equal(t, "", defaultRLCB.name)
+	assert.Equal(t, uint32(1), defaultRLCB.maxRequests)
+	assert.Equal(t, time.Duration(0), defaultRLCB.interval)
+	assert.Equal(t, time.Duration(60)*time.Second, defaultRLCB.timeout)
+	assert.Equal(t, time.Duration(60)*time.Second, defaultRLCB.halfOpenTimeout)
+	assert.NotNil(t, defaultRLCB.readyToTrip)
+	assert.Nil(t, defaultRLCB.onStateChange)
+	assert.Equal(t, StateClosed, defaultRLCB.state)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultRLCB.counts)
+	assert.True(t, defaultRLCB.expiry.IsZero())
+
+	customRLCB := newCustomRL()
+	assert.Equal(t, "cb", customRLCB.name)
+	assert.Equal(t, uint32(3), customRLCB.maxRequests)
+	assert.Equal(t, time.Duration(30)*time.Second, customRLCB.interval)
+	assert.Equal(t, time.Duration(90)*time.Second, customRLCB.timeout)
+	assert.Equal(t, time.Duration(90)*time.Second, customRLCB.halfOpenTimeout)
+	assert.NotNil(t, customRLCB.readyToTrip)
+	assert.NotNil(t, customRLCB.onStateChange)
+	assert.Equal(t, StateClosed, customRLCB.state)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customRLCB.counts)
+	assert.False(t, customRLCB.expiry.IsZero())
+
+	negativeDurationCB := newNegativeDurationRLCB()
+	assert.Equal(t, "ncb", negativeDurationCB.name)
+	assert.Equal(t, uint32(1), negativeDurationCB.maxRequests)
+	assert.Equal(t, time.Duration(0)*time.Second, negativeDurationCB.interval)
+	assert.Equal(t, time.Duration(60)*time.Second, negativeDurationCB.timeout)
+	assert.Equal(t, time.Duration(60)*time.Second, negativeDurationCB.halfOpenTimeout)
+	assert.NotNil(t, negativeDurationCB.readyToTrip)
+	assert.Nil(t, negativeDurationCB.onStateChange)
+	assert.Equal(t, StateClosed, negativeDurationCB.state)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, negativeDurationCB.counts)
+	assert.True(t, negativeDurationCB.expiry.IsZero())
+}
+
+func TestDefaultRateLimitedCircuitBreaker(t *testing.T) {
+	assert.Equal(t, "", defaultRLCB.Name())
+
+	for i := 0; i < 5; i++ {
+		assert.Nil(t, failRL(defaultRLCB))
+	}
+	assert.Equal(t, StateClosed, defaultRLCB.State())
+	assert.Equal(t, Counts{5, 0, 5, 0, 5}, defaultRLCB.counts)
+
+	assert.Nil(t, succeedRL(defaultRLCB))
+	assert.Equal(t, StateClosed, defaultRLCB.State())
+	assert.Equal(t, Counts{6, 1, 5, 1, 0}, defaultRLCB.counts)
+
+	assert.Nil(t, failRL(defaultRLCB))
+	assert.Equal(t, StateClosed, defaultRLCB.State())
+	assert.Equal(t, Counts{7, 1, 6, 0, 1}, defaultRLCB.counts)
+
+	// StateClosed to StateOpen
+	for i := 0; i < 5; i++ {
+		assert.Nil(t, failRL(defaultRLCB)) // 6 consecutive failures
+	}
+	assert.Equal(t, StateOpen, defaultRLCB.State())
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultRLCB.counts)
+	assert.False(t, defaultRLCB.expiry.IsZero())
+
+	assert.Error(t, succeedRL(defaultRLCB))
+	assert.Error(t, failRL(defaultRLCB))
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultRLCB.counts)
+
+	pseudoSleepRL(defaultRLCB, time.Duration(59)*time.Second)
+	assert.Equal(t, StateOpen, defaultRLCB.State())
+
+	// StateOpen to StateHalfOpen
+	pseudoSleepRL(defaultRLCB, time.Duration(1)*time.Second) // over Timeout
+	assert.Equal(t, StateHalfOpen, defaultRLCB.State())
+
+	// Stay in StateHalfOpen
+	assert.Nil(t, failRL(defaultRLCB))
+	assert.Equal(t, StateHalfOpen, defaultRLCB.State())
+	assert.Equal(t, Counts{1, 0, 1, 0, 1}, defaultRLCB.counts)
+
+	// StateHalfOpen to StateOpen
+	for i := 0; i < 5; i++ {
+		assert.Nil(t, failRL(defaultRLCB)) // add 5 more failures for a total of 6 consecutive failures
+	}
+	assert.Equal(t, StateOpen, defaultRLCB.State())
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultRLCB.counts)
+	assert.False(t, defaultRLCB.expiry.IsZero())
+
+	// StateOpen to StateHalfOpen
+	pseudoSleepRL(defaultRLCB, time.Duration(60)*time.Second) // over Timeout
+	assert.Equal(t, StateHalfOpen, defaultRLCB.State())
+
+	// StateHalfOpen to StateClosed
+	pseudoSleepRL(defaultRLCB, time.Duration(60)*time.Second) // over HalfOpenTimeout
+	assert.Equal(t, StateClosed, defaultRLCB.State())
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultRLCB.counts)
+	assert.True(t, defaultRLCB.expiry.IsZero())
+}
+
+func TestCustomRateLimitedCircuitBreaker(t *testing.T) {
+	assert.Equal(t, "cb", customRLCB.Name())
+
+	for i := 0; i < 5; i++ {
+		assert.Nil(t, succeedRL(customRLCB))
+		assert.Nil(t, failRL(customRLCB))
+	}
+	assert.Equal(t, StateClosed, customRLCB.State())
+	assert.Equal(t, Counts{10, 5, 5, 0, 1}, customRLCB.counts)
+
+	pseudoSleepRL(customRLCB, time.Duration(29)*time.Second)
+	assert.Nil(t, succeedRL(customRLCB))
+	assert.Equal(t, StateClosed, customRLCB.State())
+	assert.Equal(t, Counts{11, 6, 5, 1, 0}, customRLCB.counts)
+
+	pseudoSleepRL(customRLCB, time.Duration(1)*time.Second) // over Interval
+	assert.Nil(t, failRL(customRLCB))
+	assert.Equal(t, StateClosed, customRLCB.State())
+	assert.Equal(t, Counts{1, 0, 1, 0, 1}, customRLCB.counts)
+
+	// StateClosed to StateOpen
+	assert.Nil(t, succeedRL(customRLCB))
+	assert.Nil(t, failRL(customRLCB)) // failure ratio: 2/3 >= 0.6
+	assert.Equal(t, StateOpen, customRLCB.State())
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customRLCB.counts)
+	assert.False(t, customRLCB.expiry.IsZero())
+	assert.Equal(t, RLStateChange{"cb", StateClosed, StateOpen}, rlStateChange)
+
+	// StateOpen to StateHalfOpen
+	pseudoSleepRL(customRLCB, time.Duration(90)*time.Second)
+	assert.Equal(t, StateHalfOpen, customRLCB.State())
+	assert.Equal(t, RLStateChange{"cb", StateOpen, StateHalfOpen}, rlStateChange)
+
+	assert.Nil(t, succeedRL(customRLCB))
+	assert.Nil(t, succeedRL(customRLCB))
+	assert.Equal(t, StateHalfOpen, customRLCB.State())
+	assert.Equal(t, Counts{2, 2, 0, 2, 0}, customRLCB.counts)
+
+	// Rate-limited while in StateHalfOpen
+	ch1 := succeedLaterRL(customRLCB, time.Duration(100)*time.Millisecond)
+	ch2 := succeedLaterRL(customRLCB, time.Duration(100)*time.Millisecond)
+	ch3 := succeedLaterRL(customRLCB, time.Duration(100)*time.Millisecond) // 3 inflight requests
+	time.Sleep(time.Duration(50) * time.Millisecond)
+	assert.ErrorIs(t, succeedRL(customRLCB), ErrTooManyRequests) // over MaxRequests
+
+	time.Sleep(time.Duration(100) * time.Millisecond)
+	assert.Equal(t, Counts{5, 5, 0, 5, 0}, customRLCB.counts)
+	assert.Nil(t, <-ch1)
+	assert.Nil(t, <-ch2)
+	assert.Nil(t, <-ch3)
+
+	// StateHalfOpen to StateClosed
+	pseudoSleepRL(customRLCB, time.Duration(90)*time.Second) // over HalfOpenTimeout
+	assert.Equal(t, StateClosed, customRLCB.State())
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customRLCB.counts)
+	assert.False(t, customRLCB.expiry.IsZero())
+	assert.Equal(t, RLStateChange{"cb", StateHalfOpen, StateClosed}, rlStateChange)
+}
+
+func TestPanicInRequestRL(t *testing.T) {
+	assert.Panics(t, func() { _ = causePanicRL(defaultRLCB) })
+	assert.Equal(t, Counts{1, 0, 1, 0, 1}, defaultRLCB.counts)
+}
+
+func TestGenerationRL(t *testing.T) {
+	pseudoSleepRL(customRLCB, time.Duration(29)*time.Second)
+	assert.Nil(t, succeedRL(customRLCB))
+	ch := succeedLaterRL(customRLCB, time.Duration(1500)*time.Millisecond)
+	time.Sleep(time.Duration(500) * time.Millisecond)
+	assert.Equal(t, Counts{2, 1, 0, 1, 0}, customRLCB.counts)
+
+	time.Sleep(time.Duration(500) * time.Millisecond) // over Interval
+	assert.Equal(t, StateClosed, customRLCB.State())
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customRLCB.counts)
+
+	// the request from the previous generation has no effect on customRLCB.counts
+	assert.Nil(t, <-ch)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customRLCB.counts)
+}
+
+func TestCustomIsSuccessfulRL(t *testing.T) {
+	isSuccessful := func(error) bool {
+		return true
+	}
+	cb := NewRateLimitedCircuitBreaker[bool](RateLimitedCircuitBreakerSettings{
+		Settings: Settings{
+			IsSuccessful: isSuccessful,
+		},
+	})
+
+	for i := 0; i < 5; i++ {
+		assert.Nil(t, failRL(cb))
+	}
+	assert.Equal(t, StateClosed, cb.State())
+	assert.Equal(t, Counts{5, 5, 0, 5, 0}, cb.counts)
+
+	cb.counts.clear()
+
+	cb.isSuccessful = func(err error) bool {
+		return err == nil
+	}
+	for i := 0; i < 6; i++ {
+		assert.Nil(t, failRL(cb))
+	}
+	assert.Equal(t, StateOpen, cb.State())
+
+}
+
+func TestRateLimitedCircuitBreakerInParallel(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	ch := make(chan error)
+
+	const numReqs = 10000
+	routine := func() {
+		for i := 0; i < numReqs; i++ {
+			ch <- succeedRL(customRLCB)
+		}
+	}
+
+	const numRoutines = 10
+	for i := 0; i < numRoutines; i++ {
+		go routine()
+	}
+
+	total := uint32(numReqs * numRoutines)
+	for i := uint32(0); i < total; i++ {
+		err := <-ch
+		assert.Nil(t, err)
+	}
+	assert.Equal(t, Counts{total, total, 0, total, 0}, customRLCB.counts)
+}


### PR DESCRIPTION
RateLimitedCircuitBreaker is a state machine to prevent sending requests that are likely to fail.
It differs from a regular CircuitBreaker in that it has a half-open state that:
1. Allows a rate-limited number of requests to pass through, rejecting requests when the limit is reached
2. Resets the state to closed after a specified timeout
3. Uses the same tripping logic as the Closed state.